### PR TITLE
don't crash when client_try_connect fails

### DIFF
--- a/src/libc4/net/network.c
+++ b/src/libc4/net/network.c
@@ -625,7 +625,12 @@ client_try_connect(ClientState *client)
     {
         c4_log(client->c4, "Failed to connect to remote host @ %s",
                client->loc_spec_str);
-        FAIL_APR(s);
+        // We used to error out here:
+            // FAIL_APR(s);
+        // We don't do that any more, just log the failed attempt.
+        // No need to clean up the client->pending_tuples; that's handled
+        // at the end of router_do_fixpoint.
+        return;
     }
 
     /*


### PR DESCRIPTION
C4 used to error out if a remote client could not be contacted.  I removed the call to error out. It 
still generates a log message, which we may want to consider making optional.  I believe that memory management for the attempted tuples is taken care of; observed memory usage in the failure case is flat.
